### PR TITLE
Gitignore and correct link to Veforge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/vide_modules/vide-lib/src/execution/execution-context.js
+++ b/vide_modules/vide-lib/src/execution/execution-context.js
@@ -201,7 +201,7 @@ function ExecutionContext () {
   }
 }
 var transactionDetailsLinks = {
-  'Mainnet': 'https://veforge.com/transactions/',
+  'Mainnet': 'https://explore.veforge.com/transactions/',
   'Testnet': 'https://testnet.veforge.com/transactions/',
   'Unknown': 'https://testnet.veforge.com/transactions/'
 }


### PR DESCRIPTION
Minor changes:

- added gitignore to ignore installation and build files
- updated the veforge mainnet link that is now explore.veforge.com